### PR TITLE
fix small bug

### DIFF
--- a/StringyPlotter.py
+++ b/StringyPlotter.py
@@ -10,7 +10,7 @@ divisor = int(sys.argv[3])
 i = Image.open(input_image)
 ii = np.array(i)
 iii = np.where(ii==1)
-iiii = np.column_stack(reversed(iii))
+iiii = np.column_stack(list(reversed(iii)))
 iiiii = iiii[np.random.choice(iiii.shape[0],iiii.shape[0]//divisor,replace=False),:]
 
 the_first = iiiii[0]


### PR DESCRIPTION
Issue:

When using the existing code with numpy 1.26.4 I get the following error:

```
Traceback (most recent call last):
  File "[...]/StringyPlotter.py", line 13, in <module>
    iiii = np.column_stack(reversed(iii))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/numpy/lib/shape_base.py", line 609, in _column_stack_dispatcher
    return _arrays_for_stack_dispatcher(tup)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/numpy/core/shape_base.py", line 209, in _arrays_for_stack_dispatcher
    raise TypeError('arrays to stack must be passed as a "sequence" type '
TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.
```

This is because `np.column_stack` can only take a list and not a generator, but `reversed` outputs a 2-item generator.

This change converts the object back into a real list.

Thanks for making something like this available! :)